### PR TITLE
Push to GitHub Container Repository as well

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -15,6 +17,12 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Log in to the GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -26,7 +34,9 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: mawinkler/astrolive:latest
+          tags: |
+            mawinkler/astrolive:latest
+            ghcr.io/mawinkler/astrolive:latest
 
       - name: Vision One Container Security Scan Action
         uses: trendmicro/tmas-scan-action@1.0.10

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -61,14 +61,14 @@ jobs:
             SCAN_RESULT_ARTIFACT: result.json
 
       - name: Upload Scan Result Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scan-result
           path: result.json
           retention-days: 30
 
       - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sbom
           path: SBOM.json


### PR DESCRIPTION
As an alternative mirror to the Docker Hub releases, which isn't subject to the Docker Hub rate limits. https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry 

It's free for open source repos and requires no action on your end if this were to be merged. The CI job after a merge would push the same image to both Docker Hub and GHCR. 

This PR also updates the `upload-artifact` action to v4 as GitHub prevents pipelines using v3 from running (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) with:
![image](https://github.com/user-attachments/assets/7682a619-5036-4a64-9bd6-d5134f3766e2)

